### PR TITLE
Add recover-pol subcommand for stranded POL recovery

### DIFF
--- a/cmd/meta-transaction-processor/main.go
+++ b/cmd/meta-transaction-processor/main.go
@@ -80,6 +80,9 @@ func main() {
 
 			logger.Info().Msgf("Key corresponds to address %s.", send.Address())
 			return
+		case "recover-pol":
+			recoverPOL(ctx, logger, &settings, os.Args[2:])
+			return
 		case "migrate":
 			command := "up"
 			if len(os.Args) > 2 {

--- a/cmd/meta-transaction-processor/recover_pol.go
+++ b/cmd/meta-transaction-processor/recover_pol.go
@@ -1,0 +1,376 @@
+package main
+
+// TEMPORARY ops tooling: recover POL (Polygon Ecosystem Token) that landed by
+// mistake in our KMS-backed reward wallets on ETHEREUM MAINNET, sweeping it back
+// to the wallet that funded their gas.
+//
+// This is a port of the standalone `savepol` recovery onto the processor's existing
+// KMS signer, so it can run from inside the cluster (the only place the minting-key
+// KMS endpoint admits). It is deliberately self-contained in this one file and wired
+// into main.go with a single dispatch case, so it can be reverted by deleting both.
+//
+// SAFE BY DEFAULT: without --broadcast it only simulates and prints what it would do.
+//
+//   meta-transaction-processor recover-pol --key-id <id> --rpc <L1_RPC> --amount 1
+//   meta-transaction-processor recover-pol --key-id <id> --rpc <L1_RPC> --amount 1 --broadcast
+//   meta-transaction-processor recover-pol --key-id <id> --rpc <L1_RPC> --amount all --broadcast
+//
+// The Ethereum-mainnet RPC is a REQUIRED flag and is never read from settings.yaml:
+// the running service stays Polygon-only; only this manually-invoked command touches L1.
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+	"time"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/rs/zerolog"
+
+	"github.com/DIMO-Network/meta-transaction-processor/internal/config"
+	"github.com/DIMO-Network/meta-transaction-processor/internal/sender"
+)
+
+const (
+	// Ethereum mainnet. Hardcoded on purpose: this recovery only ever runs on chain 1.
+	recoverChainID = int64(1)
+
+	// POL (Polygon Ecosystem Token) on Ethereum mainnet.
+	// Verified on-chain: symbol "POL", decimals 18.
+	polToken    = "0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6"
+	polDecimals = 18
+
+	// Pinned recovery destination: the address that funded both reward wallets with
+	// their gas ETH. This is an allowlist of one -- the command refuses any other --to,
+	// so "anyone who can exec the pod" can only ever recover funds to the safe wallet,
+	// never drain them elsewhere.
+	pinnedDest = "0xB4536AfA9EE668E05503395AE17d2aD15CCd9069"
+
+	// ERC-20 selectors.
+	selTransfer  = "a9059cbb" // transfer(address,uint256)
+	selBalanceOf = "70a08231" // balanceOf(address)
+)
+
+// The KMS-backed reward wallets that received POL by mistake on Ethereum. The derived
+// KMS address MUST be one of these or we abort -- guards against pointing --key-id at
+// some unrelated key.
+var knownRewardWallets = []string{
+	"0xcce4eF41A67E28C3CF3dbc51a6CD3d004F53aCBd", // wallet A
+	"0xE92a1B8078EBc01412ba6Ef878425f35B32D6bBb", // wallet B
+}
+
+func recoverPOL(ctx context.Context, logger zerolog.Logger, settings *config.Settings, argv []string) {
+	fs := flag.NewFlagSet("recover-pol", flag.ExitOnError)
+	keyID := fs.String("key-id", "", "KMS key id/alias controlling the reward wallet (required)")
+	rpcURL := fs.String("rpc", "", "Ethereum MAINNET RPC URL (required; never taken from settings)")
+	amountArg := fs.String("amount", "", "POL amount to send, or \"all\" for the full balance (required)")
+	toArg := fs.String("to", pinnedDest, "destination (pinned to the gas-funder; any other value is rejected)")
+	broadcast := fs.Bool("broadcast", false, "actually send (otherwise dry-run / simulate only)")
+	skipConfirm := fs.Bool("yes", false, "skip the interactive confirmation prompt")
+	_ = fs.Parse(argv)
+
+	die := func(msg string) {
+		logger.Fatal().Msg(msg)
+	}
+
+	if *keyID == "" {
+		die("--key-id required")
+	}
+	if *rpcURL == "" {
+		die("--rpc required (Ethereum mainnet RPC; this service's own RPC is Polygon)")
+	}
+	if *amountArg == "" {
+		die("--amount required (a number of POL, or \"all\")")
+	}
+
+	// Enforce the destination allowlist of one.
+	toAddr := common.HexToAddress(*toArg)
+	if toAddr != common.HexToAddress(pinnedDest) {
+		die(fmt.Sprintf("destination %s is not allowlisted; this tool only recovers to the gas-funder %s", toAddr, pinnedDest))
+	}
+
+	client, err := ethclient.DialContext(ctx, *rpcURL)
+	if err != nil {
+		die("failed to dial RPC: " + err.Error())
+	}
+	defer client.Close()
+
+	// Guard: must be Ethereum mainnet.
+	chainID, err := client.ChainID(ctx)
+	if err != nil {
+		die("failed to read chain id: " + err.Error())
+	}
+	if chainID.Int64() != recoverChainID {
+		die(fmt.Sprintf("RPC chain %d != %d (Ethereum mainnet); refusing to run", chainID.Int64(), recoverChainID))
+	}
+
+	// Build the KMS signer and verify it controls a wallet we recognize.
+	kmsc, err := makeKMSClient(ctx, settings)
+	if err != nil {
+		die("failed to build KMS client: " + err.Error())
+	}
+	send, err := sender.FromKMS(ctx, kmsc, *keyID)
+	if err != nil {
+		die("failed to construct KMS signer: " + err.Error())
+	}
+	fromAddr := send.Address()
+	if !isKnownWallet(fromAddr) {
+		die(fmt.Sprintf("KMS key %s controls %s, which is not a known reward wallet; aborting", *keyID, fromAddr))
+	}
+
+	token := common.HexToAddress(polToken)
+
+	// Balances.
+	polBal, err := erc20BalanceOf(ctx, client, token, fromAddr)
+	if err != nil {
+		die("failed to read POL balance: " + err.Error())
+	}
+	ethBal, err := client.BalanceAt(ctx, fromAddr, nil)
+	if err != nil {
+		die("failed to read ETH balance: " + err.Error())
+	}
+
+	// Resolve amount.
+	var amountWei *big.Int
+	if strings.EqualFold(*amountArg, "all") {
+		amountWei = new(big.Int).Set(polBal)
+	} else {
+		amountWei, err = parseUnits(*amountArg, polDecimals)
+		if err != nil {
+			die("bad --amount: " + err.Error())
+		}
+	}
+	if amountWei.Sign() <= 0 {
+		die("amount must be > 0")
+	}
+	if amountWei.Cmp(polBal) > 0 {
+		die(fmt.Sprintf("amount %s > balance %s POL", formatUnits(amountWei, polDecimals), formatUnits(polBal, polDecimals)))
+	}
+
+	data := append(hexSelector(selTransfer), append(leftPad32(toAddr.Bytes()), leftPad32(amountWei.Bytes())...)...)
+
+	// Fees (EIP-1559) and gas.
+	head, err := client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		die("failed to read latest header: " + err.Error())
+	}
+	tip, err := client.SuggestGasTipCap(ctx)
+	if err != nil {
+		die("failed to suggest gas tip: " + err.Error())
+	}
+	maxFee := new(big.Int).Add(new(big.Int).Mul(head.BaseFee, big.NewInt(2)), tip)
+
+	callMsg := ethereum.CallMsg{From: fromAddr, To: &token, Data: data}
+	gasLimit, err := client.EstimateGas(ctx, callMsg)
+	if err != nil {
+		die("gas estimation failed (transfer would likely revert): " + err.Error())
+	}
+
+	nonce, err := client.PendingNonceAt(ctx, fromAddr)
+	if err != nil {
+		die("failed to read nonce: " + err.Error())
+	}
+
+	maxGasCost := new(big.Int).Mul(new(big.Int).SetUint64(gasLimit), maxFee)
+
+	mode := "DRY RUN (simulate only)"
+	if *broadcast {
+		mode = "*** BROADCAST ***"
+	}
+	fmt.Println("\n========== POL RECOVERY ==========")
+	fmt.Printf("Mode:        %s\n", mode)
+	fmt.Printf("Chain:       %d (Ethereum mainnet)\n", chainID.Int64())
+	fmt.Printf("From:        %s\n", fromAddr)
+	fmt.Printf("KMS key:     %s\n", *keyID)
+	fmt.Printf("To:          %s\n", toAddr)
+	allNote := ""
+	if strings.EqualFold(*amountArg, "all") {
+		allNote = "  (FULL BALANCE)"
+	}
+	fmt.Printf("Amount:      %s POL%s\n", formatUnits(amountWei, polDecimals), allNote)
+	fmt.Printf("Token:       %s\n", token)
+	fmt.Printf("Nonce:       %d\n", nonce)
+	fmt.Printf("Gas limit:   %d\n", gasLimit)
+	fmt.Printf("Max fee/gas: %s gwei\n", formatUnits(maxFee, 9))
+	fmt.Printf("Max gas cost:%s ETH  (wallet has %s ETH)\n", formatUnits(maxGasCost, 18), formatUnits(ethBal, 18))
+	fmt.Println("==================================")
+
+	if maxGasCost.Cmp(ethBal) > 0 {
+		die("insufficient ETH for gas at current fees")
+	}
+
+	// Always simulate first so we never broadcast a tx that would revert.
+	if _, err := client.CallContract(ctx, callMsg, nil); err != nil {
+		die("simulation reverted: " + err.Error())
+	}
+	fmt.Println("\nSimulation: OK (transfer would succeed)")
+
+	if !*broadcast {
+		fmt.Println("\nDry run complete. Re-run with --broadcast to send for real.")
+		return
+	}
+
+	if !*skipConfirm {
+		fmt.Printf("\nType \"send\" to broadcast %s POL from %s to %s: ", formatUnits(amountWei, polDecimals), fromAddr, toAddr)
+		reader := bufio.NewReader(os.Stdin)
+		line, _ := reader.ReadString('\n')
+		if strings.TrimSpace(line) != "send" {
+			die("aborted by user")
+		}
+	}
+
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     nonce,
+		GasTipCap: tip,
+		GasFeeCap: maxFee,
+		Gas:       gasLimit,
+		To:        &token,
+		Value:     big.NewInt(0),
+		Data:      data,
+	})
+
+	signer := types.LatestSignerForChainID(chainID)
+	sig, err := send.Sign(ctx, signer.Hash(tx))
+	if err != nil {
+		die("KMS signing failed: " + err.Error())
+	}
+	signedTx, err := tx.WithSignature(signer, sig)
+	if err != nil {
+		die("failed to attach signature: " + err.Error())
+	}
+
+	fmt.Println("\nSigning via KMS and broadcasting...")
+	if err := client.SendTransaction(ctx, signedTx); err != nil {
+		die("broadcast failed: " + err.Error())
+	}
+	hash := signedTx.Hash()
+	fmt.Printf("tx hash: %s\n", hash.Hex())
+	fmt.Println("waiting for confirmation...")
+
+	rcpt, err := waitMined(ctx, client, hash)
+	if err != nil {
+		die("error waiting for receipt: " + err.Error())
+	}
+	statusStr := "FAILED"
+	if rcpt.Status == types.ReceiptStatusSuccessful {
+		statusStr = "SUCCESS"
+	}
+	fmt.Printf("\nStatus:   %s\n", statusStr)
+	fmt.Printf("Block:    %d\n", rcpt.BlockNumber.Uint64())
+	fmt.Printf("Gas used: %d\n", rcpt.GasUsed)
+	fmt.Printf("Explorer: https://etherscan.io/tx/%s\n", hash.Hex())
+}
+
+func isKnownWallet(addr common.Address) bool {
+	for _, w := range knownRewardWallets {
+		if addr == common.HexToAddress(w) {
+			return true
+		}
+	}
+	return false
+}
+
+func erc20BalanceOf(ctx context.Context, client *ethclient.Client, token, holder common.Address) (*big.Int, error) {
+	data := append(hexSelector(selBalanceOf), leftPad32(holder.Bytes())...)
+	out, err := client.CallContract(ctx, ethereum.CallMsg{To: &token, Data: data}, nil)
+	if err != nil {
+		return nil, err
+	}
+	return new(big.Int).SetBytes(out), nil
+}
+
+func waitMined(ctx context.Context, client *ethclient.Client, hash common.Hash) (*types.Receipt, error) {
+	deadline := time.NewTimer(5 * time.Minute)
+	defer deadline.Stop()
+	tick := time.NewTicker(2 * time.Second)
+	defer tick.Stop()
+	for {
+		rcpt, err := client.TransactionReceipt(ctx, hash)
+		if err == nil {
+			return rcpt, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-deadline.C:
+			return nil, fmt.Errorf("timed out waiting for receipt for %s", hash.Hex())
+		case <-tick.C:
+		}
+	}
+}
+
+func hexSelector(sel string) []byte {
+	b := make([]byte, 4)
+	for i := 0; i < 4; i++ {
+		fmt.Sscanf(sel[i*2:i*2+2], "%02x", &b[i])
+	}
+	return b
+}
+
+func leftPad32(b []byte) []byte {
+	out := make([]byte, 32)
+	copy(out[32-len(b):], b)
+	return out
+}
+
+// parseUnits converts a decimal string (e.g. "1.5") into a base-unit integer with the
+// given number of decimals.
+func parseUnits(s string, decimals int) (*big.Int, error) {
+	s = strings.TrimSpace(s)
+	neg := strings.HasPrefix(s, "-")
+	if neg {
+		return nil, fmt.Errorf("negative amount")
+	}
+	parts := strings.SplitN(s, ".", 2)
+	intPart := parts[0]
+	if intPart == "" {
+		intPart = "0"
+	}
+	frac := ""
+	if len(parts) == 2 {
+		frac = parts[1]
+	}
+	if len(frac) > decimals {
+		return nil, fmt.Errorf("too many decimal places (max %d)", decimals)
+	}
+	frac = frac + strings.Repeat("0", decimals-len(frac))
+	combined := intPart + frac
+	v, ok := new(big.Int).SetString(combined, 10)
+	if !ok {
+		return nil, fmt.Errorf("not a valid decimal number: %q", s)
+	}
+	return v, nil
+}
+
+// formatUnits renders a base-unit integer as a decimal string with the given decimals.
+func formatUnits(v *big.Int, decimals int) string {
+	s := v.String()
+	if decimals == 0 {
+		return s
+	}
+	neg := strings.HasPrefix(s, "-")
+	if neg {
+		s = s[1:]
+	}
+	if len(s) <= decimals {
+		s = strings.Repeat("0", decimals-len(s)+1) + s
+	}
+	intPart := s[:len(s)-decimals]
+	fracPart := strings.TrimRight(s[len(s)-decimals:], "0")
+	out := intPart
+	if fracPart != "" {
+		out = intPart + "." + fracPart
+	}
+	if neg {
+		out = "-" + out
+	}
+	return out
+}

--- a/cmd/meta-transaction-processor/recover_pol.go
+++ b/cmd/meta-transaction-processor/recover_pol.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -53,9 +54,17 @@ const (
 	// never drain them elsewhere.
 	pinnedDest = "0xB4536AfA9EE668E05503395AE17d2aD15CCd9069"
 
-	// ERC-20 selectors.
-	selTransfer  = "a9059cbb" // transfer(address,uint256)
-	selBalanceOf = "70a08231" // balanceOf(address)
+	// Minimal ERC-20 ABI for the two calls we make. Using the ABI (rather than
+	// hand-encoding selectors and 32-byte words) keeps the calldata self-evidently
+	// correct for review: the reviewer reads transfer(to, amount), not byte math.
+	erc20ABI = `[
+		{"name":"transfer","type":"function","stateMutability":"nonpayable",
+		 "inputs":[{"name":"to","type":"address"},{"name":"amount","type":"uint256"}],
+		 "outputs":[{"name":"","type":"bool"}]},
+		{"name":"balanceOf","type":"function","stateMutability":"view",
+		 "inputs":[{"name":"account","type":"address"}],
+		 "outputs":[{"name":"","type":"uint256"}]}
+	]`
 )
 
 // The KMS-backed reward wallets that received POL by mistake on Ethereum. The derived
@@ -96,6 +105,11 @@ func recoverPOL(ctx context.Context, logger zerolog.Logger, settings *config.Set
 		die(fmt.Sprintf("destination %s is not allowlisted; this tool only recovers to the gas-funder %s", toAddr, pinnedDest))
 	}
 
+	erc20, err := abi.JSON(strings.NewReader(erc20ABI))
+	if err != nil {
+		die("failed to parse ERC-20 ABI: " + err.Error())
+	}
+
 	client, err := ethclient.DialContext(ctx, *rpcURL)
 	if err != nil {
 		die("failed to dial RPC: " + err.Error())
@@ -128,7 +142,7 @@ func recoverPOL(ctx context.Context, logger zerolog.Logger, settings *config.Set
 	token := common.HexToAddress(polToken)
 
 	// Balances.
-	polBal, err := erc20BalanceOf(ctx, client, token, fromAddr)
+	polBal, err := erc20BalanceOf(ctx, client, erc20, token, fromAddr)
 	if err != nil {
 		die("failed to read POL balance: " + err.Error())
 	}
@@ -154,7 +168,10 @@ func recoverPOL(ctx context.Context, logger zerolog.Logger, settings *config.Set
 		die(fmt.Sprintf("amount %s > balance %s POL", formatUnits(amountWei, polDecimals), formatUnits(polBal, polDecimals)))
 	}
 
-	data := append(hexSelector(selTransfer), append(leftPad32(toAddr.Bytes()), leftPad32(amountWei.Bytes())...)...)
+	data, err := erc20.Pack("transfer", toAddr, amountWei)
+	if err != nil {
+		die("failed to encode transfer calldata: " + err.Error())
+	}
 
 	// Fees (EIP-1559) and gas.
 	head, err := client.HeaderByNumber(ctx, nil)
@@ -278,13 +295,27 @@ func isKnownWallet(addr common.Address) bool {
 	return false
 }
 
-func erc20BalanceOf(ctx context.Context, client *ethclient.Client, token, holder common.Address) (*big.Int, error) {
-	data := append(hexSelector(selBalanceOf), leftPad32(holder.Bytes())...)
-	out, err := client.CallContract(ctx, ethereum.CallMsg{To: &token, Data: data}, nil)
+func erc20BalanceOf(ctx context.Context, client *ethclient.Client, erc20 abi.ABI, token, holder common.Address) (*big.Int, error) {
+	callData, err := erc20.Pack("balanceOf", holder)
 	if err != nil {
 		return nil, err
 	}
-	return new(big.Int).SetBytes(out), nil
+	out, err := client.CallContract(ctx, ethereum.CallMsg{To: &token, Data: callData}, nil)
+	if err != nil {
+		return nil, err
+	}
+	vals, err := erc20.Unpack("balanceOf", out)
+	if err != nil {
+		return nil, err
+	}
+	if len(vals) != 1 {
+		return nil, fmt.Errorf("unexpected balanceOf return arity %d", len(vals))
+	}
+	bal, ok := vals[0].(*big.Int)
+	if !ok {
+		return nil, fmt.Errorf("balanceOf did not return a uint256")
+	}
+	return bal, nil
 }
 
 func waitMined(ctx context.Context, client *ethclient.Client, hash common.Hash) (*types.Receipt, error) {
@@ -307,26 +338,11 @@ func waitMined(ctx context.Context, client *ethclient.Client, hash common.Hash) 
 	}
 }
 
-func hexSelector(sel string) []byte {
-	b := make([]byte, 4)
-	for i := 0; i < 4; i++ {
-		fmt.Sscanf(sel[i*2:i*2+2], "%02x", &b[i])
-	}
-	return b
-}
-
-func leftPad32(b []byte) []byte {
-	out := make([]byte, 32)
-	copy(out[32-len(b):], b)
-	return out
-}
-
 // parseUnits converts a decimal string (e.g. "1.5") into a base-unit integer with the
 // given number of decimals.
 func parseUnits(s string, decimals int) (*big.Int, error) {
 	s = strings.TrimSpace(s)
-	neg := strings.HasPrefix(s, "-")
-	if neg {
+	if strings.HasPrefix(s, "-") {
 		return nil, fmt.Errorf("negative amount")
 	}
 	parts := strings.SplitN(s, ".", 2)

--- a/cmd/meta-transaction-processor/recover_pol_test.go
+++ b/cmd/meta-transaction-processor/recover_pol_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestParseUnits(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"1", "1000000000000000000"},
+		{"1.5", "1500000000000000000"},
+		{"0.000000000000000001", "1"},
+		{"1234.567", "1234567000000000000000"},
+		{"0", "0"},
+		{".5", "500000000000000000"},
+		{"  2  ", "2000000000000000000"},
+	}
+	for _, c := range cases {
+		got, err := parseUnits(c.in, 18)
+		if err != nil {
+			t.Fatalf("parseUnits(%q) unexpected error: %v", c.in, err)
+		}
+		if got.String() != c.want {
+			t.Errorf("parseUnits(%q) = %s, want %s", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseUnitsErrors(t *testing.T) {
+	for _, in := range []string{
+		"1.0000000000000000001", // 19 fractional digits > 18 decimals
+		"-1",
+		"abc",
+		"1.2.3",
+	} {
+		if _, err := parseUnits(in, 18); err == nil {
+			t.Errorf("parseUnits(%q) expected error, got nil", in)
+		}
+	}
+}
+
+func TestOnePOLIs1e18(t *testing.T) {
+	one, err := parseUnits("1", polDecimals)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exp := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+	if one.Cmp(exp) != 0 {
+		t.Fatalf("1 POL = %s, want %s", one, exp)
+	}
+}
+
+func TestFormatUnits(t *testing.T) {
+	cases := []struct {
+		in   *big.Int
+		dec  int
+		want string
+	}{
+		{big.NewInt(1000000000000000000), 18, "1"},
+		{big.NewInt(1500000000000000000), 18, "1.5"},
+		{big.NewInt(1), 18, "0.000000000000000001"},
+		{big.NewInt(343568396), 9, "0.343568396"},
+		{big.NewInt(0), 18, "0"},
+	}
+	for _, c := range cases {
+		if got := formatUnits(c.in, c.dec); got != c.want {
+			t.Errorf("formatUnits(%s, %d) = %s, want %s", c.in, c.dec, got, c.want)
+		}
+	}
+}
+
+// parseUnits and formatUnits must round-trip for any value parseUnits accepts.
+func TestParseFormatRoundTrip(t *testing.T) {
+	for _, in := range []string{"1", "1.5", "0.000000000000000001", "1234.567", "0"} {
+		v, err := parseUnits(in, 18)
+		if err != nil {
+			t.Fatal(err)
+		}
+		back, err := parseUnits(formatUnits(v, 18), 18)
+		if err != nil {
+			t.Fatalf("re-parsing formatUnits(%q) failed: %v", in, err)
+		}
+		if back.Cmp(v) != 0 {
+			t.Errorf("round-trip %q: %s != %s", in, back, v)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds a one-off `recover-pol` subcommand that sweeps POL (Polygon Ecosystem Token) which landed by mistake in our KMS-backed reward wallets **on Ethereum mainnet** back to the wallet that funded their gas.

These wallets can only be signed for from inside the cluster: the minting KMS key is locked by its key policy to a VPC endpoint whose security group admits only the K8s node/master SGs. The processor already runs there and already has a chain-agnostic KMS signer, so this reuses `sender.FromKMS`/`Sign` rather than standing up new infra. Intended to be run via `kubectl exec` into a pod, then reverted once the recovery is complete.

## Why this doesn't touch mainline operation

The change is **strictly additive**:
- The subcommand short-circuits and `return`s in the same place `print-kms-address` and `migrate` already do — before the consumer, ticker/boost loop, gRPC server, senders, or Polygon eth client are constructed.
- No changes to `settings.yaml`, the consumer, or the ticker.
- The Ethereum-mainnet RPC is a **required `--rpc` flag, never read from settings**, so the running service stays Polygon-only. The L1 dependency exists only for the duration of a manual invocation.

## Safety guards

- **Dry-run by default** — simulates and prints; sends only with `--broadcast`.
- **Destination pinned** to the gas-funder (`0xB4536…9069`); any other `--to` is rejected.
- **Chain guard** — aborts unless the RPC reports chain `1`.
- **Wallet guard** — aborts unless the KMS key derives to a known reward wallet.
- **Simulate-before-send** via `eth_call`, plus a gas-affordability check and an interactive `type "send"` confirmation unless `--yes`.

## Usage

```
./meta-transaction-processor recover-pol --key-id <id> --rpc <L1_RPC> --amount 1            # dry run
./meta-transaction-processor recover-pol --key-id <id> --rpc <L1_RPC> --amount 1 --broadcast
```

A dry run works anywhere (GetPublicKey + L1 reads aren't covered by the key-policy deny); broadcasting needs `kms:Sign`, which only succeeds in-cluster.

## Revert

Delete `cmd/meta-transaction-processor/recover_pol.go` and remove the three-line `case "recover-pol":` from `main.go`.

## Testing

- `go build ./...` and `go vet ./cmd/...` clean.
- Validated amount parse/format round-trips, 1 POL = 1e18, and `transfer` calldata encoding (68 bytes) in a throwaway.
- Pre-existing `TestKMSSenderSign` failure is environmental (needs Docker/LocalStack via testcontainers) and is in `internal/sender`, which this PR does not modify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)